### PR TITLE
Add C++/11 Toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,12 @@ notifications:
   email:
     on_success: never
     on_failure: change
+
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
On travis, the recent VM has trouble building native exitensions without including a C++/11 compiler

This is the canonical way to include one from https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements