### PR TITLE
Normalize uuid to id (since the id is not universal)

### DIFF
--- a/glacier/src/actions/add-data-source.ts
+++ b/glacier/src/actions/add-data-source.ts
@@ -1,14 +1,14 @@
 import {ReduxStandardAction} from "./";
 
-export type AddDataSourceAction<S extends string, T, C> = ReduxStandardAction<"ADD_DATA_SOURCE", {type: S, metadata: T, cache: C, uuid: number}>;
+export type AddDataSourceAction<S extends string, T, C> = ReduxStandardAction<"ADD_DATA_SOURCE", {type: S, metadata: T, cache: C, id: number}>;
 export type AddSqliteFileDataSourceAction<S> = AddDataSourceAction<"sqlite-file", {path: string}, S>;
 export type AddMemoryDataSourceAction<S> = AddDataSourceAction<"memory", {}, S>;
 
-let uuid = 0;
+let id = 0;
 
 export function createAddDataSourceAction<C>(type: "sqlite-file", metadata: {path: string}, cache: C): AddSqliteFileDataSourceAction<C>;
 export function createAddDataSourceAction<C>(type: "memory", metadata: {}, cache: C): AddMemoryDataSourceAction<C>;
 export function createAddDataSourceAction<S extends string, M, C>(type: S, metadata: M, cache: C): AddDataSourceAction<S, M, C>;
 export function createAddDataSourceAction<S extends string, M, C>(type: S, metadata: M, cache: C): AddDataSourceAction<S, M, C> {
-    return { type: "ADD_DATA_SOURCE", payload: { type, metadata, cache, uuid: uuid++ } };
+    return { type: "ADD_DATA_SOURCE", payload: { type, metadata, cache, id: id++ } };
 }

--- a/glacier/src/actions/add-fields.ts
+++ b/glacier/src/actions/add-fields.ts
@@ -1,8 +1,10 @@
 import {ReduxStandardAction} from "./";
-import {Field} from "../model";
+import {Field, FieldDescriptor} from "../model";
 
-export type AddFieldsAction = ReduxStandardAction<"ADD_FIELDS", {fields: Field[]}>;
+export type AddFieldsAction = ReduxStandardAction<"ADD_FIELDS", {fields: FieldDescriptor[]}>;
+
+let id = 0;
 
 export function createAddFieldsAction(fields: Field[]): AddFieldsAction {
-    return {type: "ADD_FIELDS", payload: {fields}};
+    return {type: "ADD_FIELDS", payload: {fields: fields.map(f => ({name: f.name, dataSource: f.dataSource, table: f.table, id: id++}))}};
 }

--- a/glacier/src/actions/add-mark.ts
+++ b/glacier/src/actions/add-mark.ts
@@ -1,9 +1,0 @@
-import {ReduxStandardAction} from "./";
-
-let uuid = 0;
-
-export type AddMarkAction = ReduxStandardAction<"ADD_MARK", {uuid: number}>;
-
-export function createAddConfigurationAction(): AddMarkAction {
-    return { type: "ADD_MARK", payload: {uuid: uuid++}};
-}

--- a/glacier/src/actions/index.ts
+++ b/glacier/src/actions/index.ts
@@ -11,7 +11,7 @@ import {AddDataSourceAction} from "./add-data-source";
 import {RemoveDataSourceAction} from "./remove-data-source";
 import {UpdateDataCacheAction} from "./update-data-cache";
 import {AddFieldsAction} from "./add-fields";
-import {RemoveFieldsAction} from "./remove-fields";
+import {RemoveFieldsAction, RemoveFieldsByIdAction} from "./remove-fields";
 import {UpdateDescriptionAction, UpdateEncodingAction, UpdateMarkTypeAction, UpdateSizeAction} from "./configure-mark";
 
 export type AllActions = AddDataSourceAction<string, {}, {}>
@@ -22,4 +22,5 @@ export type AllActions = AddDataSourceAction<string, {}, {}>
     | UpdateMarkTypeAction
     | UpdateSizeAction
     | AddFieldsAction
-    | RemoveFieldsAction;
+    | RemoveFieldsAction
+    | RemoveFieldsByIdAction;

--- a/glacier/src/actions/remove-data-source.ts
+++ b/glacier/src/actions/remove-data-source.ts
@@ -1,7 +1,7 @@
 import {ReduxStandardAction} from "./";
 
-export type RemoveDataSourceAction = ReduxStandardAction<"REMOVE_DATA_SOURCE", {uuid: number}>;
+export type RemoveDataSourceAction = ReduxStandardAction<"REMOVE_DATA_SOURCE", {id: number}>;
 
-export function createRemoveDataSourceAction(uuid: number): RemoveDataSourceAction {
-    return {type: "REMOVE_DATA_SOURCE", payload: {uuid}};
+export function createRemoveDataSourceAction(id: number): RemoveDataSourceAction {
+    return {type: "REMOVE_DATA_SOURCE", payload: {id}};
 }

--- a/glacier/src/actions/remove-fields.ts
+++ b/glacier/src/actions/remove-fields.ts
@@ -2,7 +2,12 @@ import {ReduxStandardAction} from "./";
 import {Field} from "../model";
 
 export type RemoveFieldsAction = ReduxStandardAction<"REMOVE_FIELDS", {fields: Field[]}>;
+export type RemoveFieldsByIdAction = ReduxStandardAction<"REMOVE_FIELDS_BY_ID", {fields: number[]}>;
 
 export function createRemoveFieldsAction(fields: Field[]): RemoveFieldsAction {
     return {type: "REMOVE_FIELDS", payload: {fields}};
+}
+
+export function createRemoveFieldsByIdAction(fields: number[]): RemoveFieldsByIdAction {
+    return {type: "REMOVE_FIELDS_BY_ID", payload: {fields}};
 }

--- a/glacier/src/actions/update-data-cache.ts
+++ b/glacier/src/actions/update-data-cache.ts
@@ -1,7 +1,7 @@
 import {ReduxStandardAction} from "./";
 
-export type UpdateDataCacheAction<C> = ReduxStandardAction<"UPDATE_DATA_CACHE", {uuid: number, cache: C}>;
+export type UpdateDataCacheAction<C> = ReduxStandardAction<"UPDATE_DATA_CACHE", {id: number, cache: C}>;
 
-export function createUpdateDataCacheAction<C>(uuid: number, cache: C): UpdateDataCacheAction<C> {
-    return {type: "UPDATE_DATA_CACHE", payload: {uuid, cache}};
+export function createUpdateDataCacheAction<C>(id: number, cache: C): UpdateDataCacheAction<C> {
+    return {type: "UPDATE_DATA_CACHE", payload: {id, cache}};
 }

--- a/glacier/src/adapters/index.ts
+++ b/glacier/src/adapters/index.ts
@@ -1,7 +1,7 @@
 export interface DataAdapter {
     updateCache(): Promise<any>;
     remove(): Promise<any>;
-    uuid: number;
+    id: number;
 }
 
 export * from "./memory";

--- a/glacier/src/adapters/memory.ts
+++ b/glacier/src/adapters/memory.ts
@@ -9,22 +9,22 @@ export interface MemoryDataSourceAdapter extends DataAdapter {
 
 export function createMemoryDataSource(store: redux.Store<ModelState>): MemoryDataSourceAdapter {
     const createAction = createAddDataSourceAction("memory", {}, {});
-    const uuid = createAction.payload.uuid;
+    const id = createAction.payload.id;
     let storedData: any = {};
     const func = (((data: any) => {
         storedData = data;
     }) as MemoryDataSourceAdapter);
     func.updateCache = () => {
-        const action = createUpdateDataCacheAction(uuid, storedData);
+        const action = createUpdateDataCacheAction(id, storedData);
         store.dispatch(action);
         return Promise.resolve();
     };
     func.remove = () => {
-        const action = createRemoveDataSourceAction(uuid);
+        const action = createRemoveDataSourceAction(id);
         store.dispatch(action);
         return Promise.resolve();
     };
-    func.uuid = uuid;
+    func.id = id;
     store.dispatch(createAction);
     return func;
 }

--- a/glacier/src/adapters/sql.ts
+++ b/glacier/src/adapters/sql.ts
@@ -8,10 +8,10 @@ import {createAddDataSourceAction, createUpdateDataCacheAction, createRemoveData
 const dummy = (true as boolean as false) || knex({}); // Makes the return type of the function available for reference without calling it
 export class SqlDataSourceAdapter implements DataAdapter {
     private _conn: typeof dummy;
-    uuid: number;
+    id: number;
     constructor(private store: redux.Store<ModelState>, filename: string) {
         const action = createAddDataSourceAction("sqlite-file", {path: filename}, {});
-        this.uuid = action.payload.uuid;
+        this.id = action.payload.id;
         const connection = knex({
             client: "sqlite3",
             connection: { filename },
@@ -49,7 +49,7 @@ export class SqlDataSourceAdapter implements DataAdapter {
     updateCache() {
         let state = this.store.getState();
         let fields: {[index: string]: string[]} = state.fields.filter(item =>
-             item.dataSource === this.uuid
+             item.dataSource === this.id
         )
         .reduce((prev, curr, index) => {
             prev[curr.table] = prev[curr.table] || [];
@@ -59,7 +59,7 @@ export class SqlDataSourceAdapter implements DataAdapter {
 
         return Promise.all(Object.keys(fields).map(key => {
             return this._conn.select(...fields[key]).from(key).then(data => {
-            const action = createUpdateDataCacheAction(this.uuid, data);
+            const action = createUpdateDataCacheAction(this.id, data);
             this.store.dispatch(action);
         }, err => {
             this.store.dispatch({type: "UPDATE_DATA_CACHE", error: err});
@@ -67,7 +67,7 @@ export class SqlDataSourceAdapter implements DataAdapter {
         }));
     }
     remove() {
-        const action = createRemoveDataSourceAction(this.uuid);
+        const action = createRemoveDataSourceAction(this.id);
         this.store.dispatch(action);
         return Promise.resolve();
     }

--- a/glacier/src/model/index.ts
+++ b/glacier/src/model/index.ts
@@ -12,7 +12,7 @@ export interface DataSource<T extends string, M, C> {
     readonly type: T;
     readonly metadata: M;
     readonly cache: C;
-    readonly uuid: number;
+    readonly id: number;
 }
 
 export interface MarkState {
@@ -47,7 +47,9 @@ export interface Field {
     readonly dataSource: number;
 }
 
-export type FieldState = Field[];
+export type FieldDescriptor = Field & { id: number; }
+
+export type FieldState = FieldDescriptor[];
 
 export interface MemoryDataSource extends DataSource<"memory", {}, any> {}
 export interface SqliteFileDataSource extends DataSource<"sqlite-file", {path: string}, any> {}

--- a/glacier/src/reducers/fields.ts
+++ b/glacier/src/reducers/fields.ts
@@ -27,6 +27,17 @@ export function fields(state: FieldState | undefined, action: AllActions): Field
             );
             return remainingFields;
         }
+        case "REMOVE_FIELDS_BY_ID": {
+            let validFields = action.payload.fields.filter(
+                item => satisfies(state, field => field.id === item)
+            );
+
+            if (validFields.length !== action.payload.fields.length) throw new Error("Field not in state.");
+            let remainingFields = state.filter(
+                item => !satisfies(validFields, field => item.id === field)
+            );
+            return remainingFields;
+        }
         default: return state;
     }
 }

--- a/glacier/src/reducers/sources.ts
+++ b/glacier/src/reducers/sources.ts
@@ -19,17 +19,17 @@ export function sources(state: SourcesModelState | undefined, action: AllActions
     switch (action.type) {
         case "ADD_DATA_SOURCE": {
             // TODO: Consider issuing error if action.payload.uuid is already present in the state?
-            if (state[action.payload.uuid]) return state;
-            return {...state, [action.payload.uuid]: action.payload};
+            if (state[action.payload.id]) return state;
+            return {...state, [action.payload.id]: action.payload};
         }
         case "REMOVE_DATA_SOURCE": {
             // TODO: Consider issuing error if action.payload.uuid is not already present in the state?
-            return filterState(state, action.payload.uuid);
+            return filterState(state, action.payload.id);
         }
         case "UPDATE_DATA_CACHE": {
-            const found = state[action.payload.uuid];
+            const found = state[action.payload.id];
             if (!found) return state; // TODO: Issue error if no cache is found to place update into?
-            return {...state, [action.payload.uuid]: {...found as DataSource<any, any, any>, cache: action.payload.cache}};
+            return {...state, [action.payload.id]: {...found as DataSource<any, any, any>, cache: action.payload.cache}};
         }
         default: return state;
     }

--- a/glacier/src/test/importer.spec.ts
+++ b/glacier/src/test/importer.spec.ts
@@ -76,7 +76,7 @@ describe("glacier as a model", () => {
     it("should be usable as a tool to consume structured data and emit visualizations", async () => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(addFields),
             glacier.createUpdateMarkTypeAction("point"),
@@ -87,7 +87,7 @@ describe("glacier as a model", () => {
                 y: {field: "ListPrice", type: "quantitative"}
             })
         );
-        const exporter = glacier.createSvgExporter(model, adapter.uuid);
+        const exporter = glacier.createSvgExporter(model, adapter.id);
 
         await adapter.updateCache();
         await baseline("1-structuredData", await exporter.export());
@@ -97,7 +97,7 @@ describe("glacier as a model", () => {
     it("should be usable to change mark type", async() => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(addFields),
             glacier.createUpdateMarkTypeAction("line"),
@@ -108,7 +108,7 @@ describe("glacier as a model", () => {
                 y: {field: "ListPrice", type: "quantitative"}
             })
         );
-        const exporter = glacier.createSvgExporter(model, adapter.uuid);
+        const exporter = glacier.createSvgExporter(model, adapter.id);
 
         await adapter.updateCache();
         await baseline("2-marks", await exporter.export());
@@ -118,7 +118,7 @@ describe("glacier as a model", () => {
     it("should be usable to change size", async() => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(addFields),
             glacier.createUpdateMarkTypeAction("point"),
@@ -129,7 +129,7 @@ describe("glacier as a model", () => {
                 y: {field: "ListPrice", type: "quantitative"}
             })
         );
-        const exporter = glacier.createSvgExporter(model, adapter.uuid);
+        const exporter = glacier.createSvgExporter(model, adapter.id);
 
         await adapter.updateCache();
         await baseline("3-size", await exporter.export());
@@ -139,7 +139,7 @@ describe("glacier as a model", () => {
     it("should be usable to change encoding", async() => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(addFields),
             glacier.createUpdateMarkTypeAction("point"),
@@ -150,7 +150,7 @@ describe("glacier as a model", () => {
                 x: {field: "ListPrice", type: "quantitative"}
             })
         );
-        const exporter = glacier.createSvgExporter(model, adapter.uuid);
+        const exporter = glacier.createSvgExporter(model, adapter.id);
 
         await adapter.updateCache();
         await baseline("4-encoding", await exporter.export());
@@ -160,7 +160,7 @@ describe("glacier as a model", () => {
     it("should be able to change description", async() => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(addFields),
             glacier.createUpdateMarkTypeAction("point"),
@@ -171,7 +171,7 @@ describe("glacier as a model", () => {
                 y: {field: "ListPrice", type: "quantitative"}
         })
         );
-        const exporter = glacier.createSvgExporter(model, adapter.uuid);
+        const exporter = glacier.createSvgExporter(model, adapter.id);
 
         await adapter.updateCache();
         await baseline("1-structuredData", await exporter.export()); // NOT A BUG - uses the same baseline as the first baseline
@@ -181,7 +181,7 @@ describe("glacier as a model", () => {
     it("should create an action to add fields", () => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const fields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const fields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(fields)
         );
@@ -201,8 +201,8 @@ describe("glacier as a model", () => {
     it("should create an action to remove fields", async() => {
         let model = glacier.createModel();
         const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
-        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.uuid}, {name: "ListPrice", table: "Product", dataSource: adapter.uuid}, {name: "Weight", table: "Product", dataSource: adapter.uuid}];
-        const removeFields = [{name: "ListPrice", table: "Product", dataSource: adapter.uuid}];
+        const addFields = [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}, {name: "Weight", table: "Product", dataSource: adapter.id}];
+        const removeFields = [{name: "ListPrice", table: "Product", dataSource: adapter.id}];
         dispatchSequence(model,
             glacier.createAddFieldsAction(addFields),
             glacier.createRemoveFieldsAction(removeFields),
@@ -225,10 +225,46 @@ describe("glacier as a model", () => {
 
         expect(actualTable).to.equal(expectTable);
 
-        const exporter = glacier.createSvgExporter(model, adapter.uuid);
+        const exporter = glacier.createSvgExporter(model, adapter.id);
 
         await adapter.updateCache();
-        await baseline("5-Product Weight", await exporter.export()); // NOT A BUG - uses the same baseline as the first baseline
+        await baseline("5-Product Weight", await exporter.export());
+        await adapter.remove();
+    });
+
+    it("should create an action to remove fields by id", async() => {
+        let model = glacier.createModel();
+        const adapter = glacier.createSqlFileDataSource(model, "../data/CycleChain.sqlite");
+        const addFields = glacier.createAddFieldsAction(
+            [{name: "DaysToManufacture", table: "Product", dataSource: adapter.id}, {name: "ListPrice", table: "Product", dataSource: adapter.id}, {name: "Weight", table: "Product", dataSource: adapter.id}]
+        );
+        const removeFields = glacier.createRemoveFieldsAction([addFields.payload.fields[1]]);
+        dispatchSequence(model,
+            addFields,
+            removeFields,
+            glacier.createUpdateMarkTypeAction("bar"),
+            glacier.createUpdateSizeAction(255, 264),
+            glacier.createUpdateEncodingAction({
+                x: {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}},
+                y: {field: "Weight", type: "quantitative"},
+        })
+        );
+        let state = model.getState();
+        expect(state.fields.length).to.equal(2);
+
+        let expectName = addFields.payload.fields[0].name;
+        let actualName = state.fields[0].name;
+        expect(actualName).to.equal(expectName);
+
+        let expectTable = addFields.payload.fields[0].table;
+        let actualTable = state.fields[0].table;
+
+        expect(actualTable).to.equal(expectTable);
+
+        const exporter = glacier.createSvgExporter(model, adapter.id);
+
+        await adapter.updateCache();
+        await baseline("5-Product Weight", await exporter.export()); // NOT A BUG - uses the same baseline as the fifth baseline
         await adapter.remove();
     });
 });


### PR DESCRIPTION
Also add ids to the fields so they are more easily selectable (and referable).  We will need to abstract the name/table fields of the action behind a type parameter dependent on the data source type in the near future, too I'll probably take care of the leaky abstraction as another pre-data-fusion PR in a bit).

Also deleted the `add-mark.ts` file, which was unreferenced by the rest of our code - I suspect it was introduced in a monolithic PR and was missed.