### PR TITLE
Factor encoding out into channel actions

### DIFF
--- a/glacier/src/actions/channels.ts
+++ b/glacier/src/actions/channels.ts
@@ -1,0 +1,19 @@
+import {ReduxStandardAction} from "./";
+import {Channel, ChannelArguments} from "../model";
+
+export type AddChannelAction<T extends Channel> = ReduxStandardAction<"ADD_CHANNEL", {kind: T, value: ChannelArguments<T>}>
+export type RemoveChannelAction<T extends Channel> = ReduxStandardAction<"REMOVE_CHANNEL", {kind: T}>
+export type UpdateChannelAction<T extends Channel> = ReduxStandardAction<"UPDATE_CHANNEL", {kind: T, value: ChannelArguments<T>}>
+
+export function createAddChannelAction<T extends Channel>(kind: T, value: ChannelArguments<T>): AddChannelAction<T> {
+    return {type: "ADD_CHANNEL", payload: {kind, value}};
+}
+
+export function createRemoveChannelAction<T extends Channel>(kind: T): RemoveChannelAction<T> {
+    return {type: "REMOVE_CHANNEL", payload: {kind}};
+}
+
+export function createUpdateChannelAction<T extends Channel>(kind: T, value: ChannelArguments<T>): UpdateChannelAction<T> {
+    return {type: "UPDATE_CHANNEL", payload: {kind, value}};
+}
+

--- a/glacier/src/actions/configure-mark.ts
+++ b/glacier/src/actions/configure-mark.ts
@@ -1,10 +1,8 @@
 import {ReduxStandardAction} from "./";
-import {Encoding} from "../model/index";
 
 export type UpdateMarkAction<K extends string, V> = ReduxStandardAction<"UPDATE_MARK", {settingName: K, settingValue: V}>;
 export type UpdateSizeAction = UpdateMarkAction<"size", {width: number, height: number}>;
 export type UpdateMarkTypeAction = UpdateMarkAction<"markType", string>;
-export type UpdateEncodingAction = UpdateMarkAction<"encoding", Encoding>;
 export type UpdateDescriptionAction = UpdateMarkAction<"desc", string>;
 
 export function createMarkConfiguration<K extends string, V>(settingName: K, settingValue: V): UpdateMarkAction<K, V> {
@@ -19,9 +17,6 @@ export function createUpdateSizeAction(height: number, width: number): UpdateSiz
     return {type: "UPDATE_MARK", payload: {settingName: "size", settingValue: {width: width, height: height}}};
 }
 
-export function createUpdateEncodingAction(encoding: Encoding): UpdateEncodingAction {
-    return {type: "UPDATE_MARK", payload: {settingName: "encoding", settingValue: encoding}};
-}
 export function createUpdateDescriptionAction(desc: string): UpdateDescriptionAction {
     return {type: "UPDATE_MARK", payload: {settingName: "desc", settingValue: desc}};
 }

--- a/glacier/src/actions/index.ts
+++ b/glacier/src/actions/index.ts
@@ -8,25 +8,30 @@ export * from "./add-fields";
 export * from "./remove-fields";
 export * from "./add-join";
 export * from "./remove-join";
+export * from "./channels";
 
 import {AddDataSourceAction} from "./add-data-source";
 import {RemoveDataSourceAction} from "./remove-data-source";
 import {UpdateDataCacheAction} from "./update-data-cache";
 import {AddFieldsAction} from "./add-fields";
 import {RemoveFieldsAction, RemoveFieldsByIdAction} from "./remove-fields";
-import {UpdateDescriptionAction, UpdateEncodingAction, UpdateMarkTypeAction, UpdateSizeAction} from "./configure-mark";
+import {UpdateDescriptionAction, UpdateMarkTypeAction, UpdateSizeAction} from "./configure-mark";
 import {AddJoinAction} from "./add-join";
 import {RemoveJoinAction} from "./remove-join";
+import {AddChannelAction, RemoveChannelAction, UpdateChannelAction} from "./channels";
+import {Channel} from "../model";
 
 export type AllActions = AddDataSourceAction<string, {}, {}>
     | RemoveDataSourceAction
     | UpdateDataCacheAction<{}>
     | UpdateDescriptionAction
-    | UpdateEncodingAction
     | UpdateMarkTypeAction
     | UpdateSizeAction
     | AddFieldsAction
     | RemoveFieldsAction
     | RemoveFieldsByIdAction
     | AddJoinAction
-    | RemoveJoinAction;
+    | RemoveJoinAction
+    | AddChannelAction<Channel>
+    | RemoveChannelAction<Channel>
+    | UpdateChannelAction<Channel>;

--- a/glacier/src/exporters/svg.ts
+++ b/glacier/src/exporters/svg.ts
@@ -4,9 +4,62 @@ declare global {
 }
 import * as vega from "vega";
 import redux = require("redux");
-import {ModelState, MarkState} from "../";
+import {ModelState, MarkState, Encoding, ChannelState, FieldId, FieldState, ChannelDef} from "../";
 import {Exporter} from "./";
 import alasql = require("alasql");
+
+
+function lookupName(f: FieldId, fields: FieldState): string {
+    return fields[f].name;
+}
+
+function remapFieldsToNames(channels: ChannelState, fields: FieldState): ChannelState {
+    const newState: Encoding = {};
+    for (const k of Object.keys(channels)) {
+        const key = k as keyof ChannelState;
+        const ch = channels[key];
+        let replacement: ChannelDef | undefined = undefined;
+        if (ch) {
+            if (ch.field) {
+                const f = ch.field;
+                if (typeof f === "number") {
+                    const field = f as FieldId;
+                    replacement = { ...ch, field: lookupName(f, fields) } as ChannelDef;
+                }
+            }
+        }
+        newState[key] = (replacement || channels[key]) as ChannelDef;
+    }
+    return newState;
+}
+
+function remapFieldsToJoinNames(channels: ChannelState, fields: FieldState): ChannelState {
+    const newState: Encoding = {};
+    for (const k of Object.keys(channels)) {
+        const key = k as keyof ChannelState;
+        const ch = channels[key];
+        let replacement: ChannelDef | undefined = undefined;
+        if (ch) {
+            if (ch.field) {
+                const f = ch.field;
+                if (typeof f === "number") {
+                    const field = f as FieldId;
+                    replacement = { ...ch, field: `${lookupName(f, fields)}_${f}` } as ChannelDef;
+                    // Patch axis titles, too
+                    if (replacement.axis && !replacement.axis.title) {
+                        replacement.axis.title = lookupName(f, fields);
+                    }
+                    if (!replacement.axis) {
+                        replacement.axis = {title: lookupName(f, fields)};
+                    }
+                }
+            }
+        }
+        newState[key] = (replacement || channels[key]) as ChannelDef;
+    }
+    return newState;
+}
+
 
 export function createSvgExporter(store: redux.Store<ModelState>) {
     const updater = ((() => {
@@ -14,15 +67,16 @@ export function createSvgExporter(store: redux.Store<ModelState>) {
         // store.getState()
     }) as Exporter<string>);
     updater.export = async () => {
-        const {sources, marks, fields: fieldTable, transforms} = store.getState();
+        const {sources, marks, fields: fieldTable, transforms, channels} = store.getState();
         const fields = Object.keys(fieldTable).map(f => fieldTable[+f]);
-        const spec: MarkState & {data?: any} = Object.create(marks);
+        const spec: MarkState & {data?: any} & {encoding?: Encoding} = Object.create(marks);
         // Simple case: all selected fields from same data source
         const dataSources = Object.keys(fields.reduce((state, f) => (state[f.dataSource] = true, state), {} as { [index: number]: boolean }));
         if (dataSources.length === 1) {
             spec.data = {
                 values: fields.map(f => sources[f.dataSource].cache)[0]
             };
+            spec.encoding = remapFieldsToNames(channels, fieldTable) as Encoding;
         }
         else {
             // TODO: Issue error when there aren't enough joins to join all selected fields!
@@ -39,6 +93,7 @@ export function createSvgExporter(store: redux.Store<ModelState>) {
             tables.unshift(tables.pop()); // Move last element to the front, since we likewise use the last data source first in our query
             const data = alasql(query, tables);
             spec.data = {values: data};
+            spec.encoding = remapFieldsToJoinNames(channels, fieldTable) as Encoding;
         }
         return await new Promise<string>((resolve, reject) => {
             const {spec: compiled} = vl.compile(spec);

--- a/glacier/src/exporters/svg.ts
+++ b/glacier/src/exporters/svg.ts
@@ -23,7 +23,6 @@ function remapFieldsToNames(channels: ChannelState, fields: FieldState): Channel
             if (ch.field) {
                 const f = ch.field;
                 if (typeof f === "number") {
-                    const field = f as FieldId;
                     replacement = { ...ch, field: lookupName(f, fields) } as ChannelDef;
                 }
             }
@@ -43,7 +42,6 @@ function remapFieldsToJoinNames(channels: ChannelState, fields: FieldState): Cha
             if (ch.field) {
                 const f = ch.field;
                 if (typeof f === "number") {
-                    const field = f as FieldId;
                     replacement = { ...ch, field: `${lookupName(f, fields)}_${f}` } as ChannelDef;
                     // Patch axis titles, too
                     if (replacement.axis && !replacement.axis.title) {

--- a/glacier/src/model/index.ts
+++ b/glacier/src/model/index.ts
@@ -84,7 +84,7 @@ export interface ScaleDef {
     zero?: boolean;
     useRawDomain?: boolean;
 
-    //ordinal only
+    // ordinal only
     bandSize?: number | "fit";
     padding?: number;
 }

--- a/glacier/src/model/index.ts
+++ b/glacier/src/model/index.ts
@@ -5,6 +5,7 @@ export interface ModelState {
     readonly marks: MarkState;
     readonly fields: FieldState;
     readonly transforms: TransformsState;
+    readonly channels: ChannelState;
 }
 
 export interface SourcesModelState {
@@ -30,24 +31,158 @@ export interface MarkState {
         readonly height: number
     };
     readonly description?: string;
-    readonly encoding?: Encoding;
 }
+
+export type DeepReadonly<T> = {
+    readonly [K in keyof T]: DeepReadonly<T[K]>;
+}
+
+export type ChannelState = {
+    readonly [K in Channel]?: DeepReadonly<ChannelArguments<K>>;
+}
+
+export interface FieldChannelDef extends BaseChannelDef {
+    // String identifying field of channel
+    field: string | FieldId; // FieldId is a local addition. Subtraction types would make it easier to type this correctly
+    // Type of channel
+    type: "quantitative" | "temporal" | "ordinal" | "nominal" | "Q" | "T" | "O" | "N";
+    // Aggregation to perform of the field, if desired
+    aggregate?: "mean" | "sum" | "median" | "min" | "max" | "count";
+    // If the field needs to be sorted, how it should be sorted
+    sort?: "ascending" | "descending" | "none";
+    // If the field is temporal, what granularity of time units to show, eg "year" or "yearmonth"
+    timeUnit?: string; // Way too many options to enumerate here
+    // If the field should be binned
+    bin?: boolean;
+}
+
+export interface ValueChannelDef extends BaseChannelDef {
+    // Used for specifying constant values rather than fields, mutually exclusive with field + type
+    field?: undefined; // This should make this discernable from field channels defs
+    value: string | number; // Mutually exclusive with field
+}
+
+export interface BaseChannelDef {
+    scale?: ScaleDef;
+    axis?: AxisDef | false;
+    legend?: LegendDef | false;
+}
+
+export type ChannelDef = FieldChannelDef | ValueChannelDef;
+
+// TODO: ScaleDef is dependent on field type, and different definitions should exist for each type
+export interface ScaleDef {
+    type?: "linear" | "log" | "pow" | "sqrt" | "quantile" | "quantize" | "threshold" | "time" | "ordinal";
+    domain?: [number, number] | number[] | [DateTimeDef, DateTimeDef];
+    range?: string[] | string | [number, number] | number[];
+    round?: boolean;
+
+    // quantitative only
+    clamp?: boolean; // Also time
+    exponent?: number;
+    nice?: boolean | string; // bool for quant, string for time
+    zero?: boolean;
+    useRawDomain?: boolean;
+
+    //ordinal only
+    bandSize?: number | "fit";
+    padding?: number;
+}
+
+export interface DateTimeDef {
+    year?: number;
+    quarter?: 1 | 2 | 3 | 4;
+    month?: string | number;
+    date?: number; // TODO: could use literal types 1-31
+    day?: number | string; // TODO: could use literal numbers 1-7
+    hours?: number; // TODO: could use literal number 0-23
+    minutes?: number; // TODO: could use literal types 0-59
+    seconds?: number; // TODO: could use literal types 0-59
+    milliseconds?: number; // TODO: could use literal type 0-999
+}
+
+export interface AxisDef {
+    axisColor?: string;
+    axisWidth?: number;
+    layer?: "front" | "back";
+    offset?: number;
+    // Dependent on being in the row or column channels
+    orient?: "top" | "bottom" | "left" | "right";
+    grid?: boolean;
+    gridColor?: string;
+    gridDash?: number[];
+    gridOpacity?: number;
+    gridWidth?: number;
+    labels?: boolean;
+    format?: string;
+    labelAngle?: number;
+    labelMaxLength?: number;
+    shortTimeLabels?: boolean;
+    subdivide?: number;
+    ticks?: number;
+    tickColor?: string;
+    tickLabelColor?: string;
+    tickLabelFont?: string;
+    tickLabelFontSize?: number;
+    tickPadding?: number;
+    tickSize?: number;
+    tickSizeMajor?: number;
+    tickSizeMinor?: number;
+    tickSizeEnd?: number;
+    tickWidth?: number;
+    values?: number[] | DateTimeDef[];
+    title?: string;
+    titleColor?: string;
+    titleFont?: string;
+    titleFontWeight?: number;
+    titleFontSize?: number;
+    titleOffset?: number;
+    titleMaxLength?: number;
+    characterWidth?: number;
+}
+
+export interface LegendDef {
+    orient?: "left" | "right";
+    offset?: number;
+    values?: DateTimeDef[] | string[] | number[];
+    format?: string;
+    labelAlign?: string;
+    labelBaseline?: string;
+    labelCOlor?: string;
+    labelFont?: string;
+    labelFontSize?: number;
+    shortTimeLabels: boolean;
+    symbolColor?: string;
+    symbolShape?: string;
+    symbolSize?: number;
+    symbolStrokeWidth?: number;
+    title?: string;
+    titleColor?: string;
+    titleFont?: string;
+    titleFontSize?: string;
+    titleFontWeight: string;
+}
+
+// TODO: Pull detailed Encoding type from latest vega-lite dts
 export interface Encoding {
-    readonly x?: {};
-    readonly y?: {};
-    readonly x2?: {};
-    readonly y2?: {};
-    readonly color?: {};
-    readonly opacity?: {};
-    readonly size?: {};
-    readonly shape?: {};
-    readonly detail?: {};
-    readonly text?: {};
-    readonly path?: {};
-    readonly order?: {};
-    readonly row?: {};
-    readonly column?: {};
+    x?: ChannelDef;
+    y?: ChannelDef;
+    x2?: ChannelDef;
+    y2?: ChannelDef;
+    color?: ChannelDef;
+    opacity?: ChannelDef;
+    size?: ChannelDef;
+    shape?: ChannelDef;
+    detail?: ChannelDef;
+    text?: ChannelDef;
+    path?: ChannelDef;
+    order?: ChannelDef;
+    row?: ChannelDef;
+    column?: ChannelDef;
 };
+
+export type Channel = keyof Encoding;
+export type ChannelArguments<T extends Channel> = Encoding[T];
 
 export interface Field {
     readonly name: string;

--- a/glacier/src/reducers/channels.ts
+++ b/glacier/src/reducers/channels.ts
@@ -1,0 +1,28 @@
+import {ChannelState} from "../model";
+import {AllActions} from "../actions";
+
+export function channels(state: ChannelState | undefined, action: AllActions): ChannelState {
+    if (!state) {
+        return {};
+    }
+    if (action.error) {
+        throw action.error;
+    }
+    switch (action.type) {
+        case "ADD_CHANNEL": {
+            if (state[action.payload.kind]) throw new Error(`Channel ${action.payload.kind} already set!`);
+            return {...state, [action.payload.kind]: action.payload.value};
+        }
+        case "REMOVE_CHANNEL": {
+            if (!state[action.payload.kind]) throw new Error(`Channel ${action.payload.kind} does not exist!`);
+            const newState = {...state};
+            delete newState[action.payload.kind];
+            return newState;
+        }
+        case "UPDATE_CHANNEL": {
+            if (!state[action.payload.kind]) throw new Error(`Channel ${action.payload.kind} does not exist!`);
+            return {...state, [action.payload.kind]: action.payload.value};
+        }
+        default: return state;
+    }
+}

--- a/glacier/src/reducers/index.ts
+++ b/glacier/src/reducers/index.ts
@@ -2,3 +2,4 @@ export * from "./sources";
 export * from "./marks";
 export * from "./fields";
 export * from "./transforms";
+export * from "./channels";

--- a/glacier/src/reducers/marks.ts
+++ b/glacier/src/reducers/marks.ts
@@ -14,9 +14,6 @@ export function marks(state: MarkState | undefined, action: AllActions): MarkSta
                 case "desc": {
                     return {...state, description: action.payload.settingValue};
                 }
-                case "encoding": {
-                    return {...state, encoding: action.payload.settingValue};
-                }
                 case "size": {
                     return {...state, width: action.payload.settingValue.width, height: action.payload.settingValue.height};
                 }

--- a/glacier/src/test/importer.spec.ts
+++ b/glacier/src/test/importer.spec.ts
@@ -95,10 +95,8 @@ describe("glacier as a model", () => {
             glacier.createUpdateMarkTypeAction("point"),
             glacier.createUpdateDescriptionAction("Test Plot"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "quantitative"},
-                y: {field: "ListPrice", type: "quantitative"}
-            })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "quantitative"}),
+            glacier.createAddChannelAction("y", {field: "ListPrice", type: "quantitative"})
         );
         const exporter = glacier.createSvgExporter(model);
 
@@ -116,10 +114,8 @@ describe("glacier as a model", () => {
             glacier.createUpdateMarkTypeAction("line"),
             glacier.createUpdateDescriptionAction("Test Plot"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "quantitative"},
-                y: {field: "ListPrice", type: "quantitative"}
-            })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "quantitative"}),
+            glacier.createAddChannelAction("y", {field: "ListPrice", type: "quantitative"})
         );
         const exporter = glacier.createSvgExporter(model);
 
@@ -137,10 +133,8 @@ describe("glacier as a model", () => {
             glacier.createUpdateMarkTypeAction("point"),
             glacier.createUpdateDescriptionAction("Test Plot"),
             glacier.createUpdateSizeAction(100, 900),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "quantitative"},
-                y: {field: "ListPrice", type: "quantitative"}
-            })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "quantitative"}),
+            glacier.createAddChannelAction("y", {field: "ListPrice", type: "quantitative"})
         );
         const exporter = glacier.createSvgExporter(model);
 
@@ -158,10 +152,8 @@ describe("glacier as a model", () => {
             glacier.createUpdateMarkTypeAction("point"),
             glacier.createUpdateDescriptionAction("Test Plot"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                y: {field: "DaysToManufacture", type: "quantitative"},
-                x: {field: "ListPrice", type: "quantitative"}
-            })
+            glacier.createAddChannelAction("y", {field: "DaysToManufacture", type: "quantitative"}),
+            glacier.createAddChannelAction("x", {field: "ListPrice", type: "quantitative"})
         );
         const exporter = glacier.createSvgExporter(model);
 
@@ -179,10 +171,8 @@ describe("glacier as a model", () => {
             glacier.createUpdateMarkTypeAction("point"),
             glacier.createUpdateDescriptionAction("Test Plot break"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "quantitative"},
-                y: {field: "ListPrice", type: "quantitative"}
-        })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "quantitative"}),
+            glacier.createAddChannelAction("y", {field: "ListPrice", type: "quantitative"})
         );
         const exporter = glacier.createSvgExporter(model);
 
@@ -215,10 +205,8 @@ describe("glacier as a model", () => {
             glacier.createRemoveFieldsAction(removeFields),
             glacier.createUpdateMarkTypeAction("bar"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}},
-                y: {field: "Weight", type: "quantitative"},
-        })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}}),
+            glacier.createAddChannelAction("y", {field: "Weight", type: "quantitative"})
         );
         let state = model.getState();
         expect(Object.keys(state.fields).length).to.equal(2);
@@ -247,10 +235,8 @@ describe("glacier as a model", () => {
             removeFields,
             glacier.createUpdateMarkTypeAction("bar"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}},
-                y: {field: "Weight", type: "quantitative"},
-        })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}}),
+            glacier.createAddChannelAction("y", {field: "Weight", type: "quantitative"})
         );
         let state = model.getState();
         expect(Object.keys(state.fields).length).to.equal(2);
@@ -276,10 +262,8 @@ describe("glacier as a model", () => {
             glacier.createRemoveFieldsAction(removeFields),
             glacier.createUpdateMarkTypeAction("area"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}},
-                y: {field: "Weight", type: "quantitative"},
-        })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}}),
+            glacier.createAddChannelAction("y", {field: "Weight", type: "quantitative"})
         );
 
         const glacierLib = fs.readFileSync(root`./glacier/dist/local/glacier.js`);
@@ -302,10 +286,8 @@ describe("glacier as a model", () => {
             glacier.createRemoveFieldsAction(removeFields),
             glacier.createUpdateMarkTypeAction("bar"),
             glacier.createUpdateSizeAction(255, 264),
-            glacier.createUpdateEncodingAction({
-                x: {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}},
-                y: {field: "Weight", type: "quantitative"},
-        })
+            glacier.createAddChannelAction("x", {field: "DaysToManufacture", type: "ordinal", scale: {bandSize: 20}}),
+            glacier.createAddChannelAction("y", {field: "Weight", type: "quantitative"})
         );
 
         const glacierLib = fs.readFileSync(root`./glacier/dist/local/glacier.js`);
@@ -348,12 +330,8 @@ describe("glacier as a model", () => {
             glacier.createUpdateDescriptionAction("MPG v DJI"),
             glacier.createUpdateSizeAction(255, 264),
             glacier.createAddJoinAction(addFields.payload.fields[2].id, addFields.payload.fields[3].id),
-            glacier.createUpdateEncodingAction({
-                // TODO: BREAK DOWN ENCODING ACTION TO MAKE FIELD SELECTION FOR AXES WHEN JOINS MANGLE NAMES INTUITIVE
-                // SINCE ROW NOW THIS IS PRETTY AWFUL
-                x: {field: `${addFields.payload.fields[1].name}_${addFields.payload.fields[1].id}`, type: "quantitative", axis: { title: "MPG" } },
-                y: {field: `${addFields.payload.fields[4].name}_${addFields.payload.fields[4].id}`, type: "quantitative", axis: { title: "Dow Jones Indstrial Average" } }
-            })
+            glacier.createAddChannelAction("x", {field: addFields.payload.fields[1].id, type: "quantitative", axis: { title: "MPG" }}),
+            glacier.createAddChannelAction("y", {field: addFields.payload.fields[4].id, type: "quantitative", axis: { title: "Dow Jones Indstrial Average" }})
         );
         const exporter = glacier.createSvgExporter(model);
 


### PR DESCRIPTION
I spoke about this on Thursday, but this is necessary to 1. make the encoding interface easier to consume, and 2. allow joined fields to be easily referenced (using their field id) without leaking implementation details. This _also_ includes much more of the encoding object's actual types (some out of necessity, some out of a desire for completeness).

@Omodi You did the original encoding work, you should look through this in detail.

A point of potential contention is that right now I still allow fields to be referenced by name - this can be a footgun, as it will break if you start using joins but keep using names, so it is possible that we could remove that convenience and force using field ids all the time to remove the footgun.