### PR TITLE
Allow composed stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-loader": "^0.8.2",
     "ts-node": "^1.3.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.2.2",
+    "typescript": "^2.3.2",
     "webpack": "^1.13.3",
     "webpack-stream": "^3.2.0"
   },

--- a/src/actions/add-data-source.ts
+++ b/src/actions/add-data-source.ts
@@ -8,7 +8,7 @@ export type AddMemoryDataSourceAction<S> = AddDataSourceAction<"memory", {}, S>;
 
 let id = 0;
 
-export function createAddDataSourceAction<C>(type: "sqlite-file", metadata: {path: string}, cache: C, adapter: SqlDataSourceAdapter): AddSqliteFileDataSourceAction<C>;
+export function createAddDataSourceAction<C, S>(type: "sqlite-file", metadata: {path: string}, cache: C, adapter: SqlDataSourceAdapter<S>): AddSqliteFileDataSourceAction<C>;
 export function createAddDataSourceAction<C>(type: "memory", metadata: {}, cache: C, adapter: MemoryDataSourceAdapter): AddMemoryDataSourceAction<C>;
 export function createAddDataSourceAction<S extends string, M, C>(type: S, metadata: M, cache: C, adapter: DataAdapter): AddDataSourceAction<S, M, C>;
 export function createAddDataSourceAction<S extends string, M, C>(type: S, metadata: M, cache: C, adapter: DataAdapter): AddDataSourceAction<S, M, C> {

--- a/src/adapters/jsonblob.ts
+++ b/src/adapters/jsonblob.ts
@@ -1,12 +1,11 @@
 import redux = require("redux");
-import { ModelState } from "../";
 import { DataAdapter } from "./";
 import { createAddDataSourceAction } from "../actions";
 import { SinglyLoadedMemoryDataSource } from "./single-memory-load-base";
 
 export interface JSONDataSourceAdapter extends DataAdapter {}
 
-export function createJSONDataSource(store: redux.Store<ModelState>, content: string): JSONDataSourceAdapter {
+export function createJSONDataSource(store: redux.Store<{}>, content: string): JSONDataSourceAdapter {
     const storedData = JSON.parse(content);
     const adapter: JSONDataSourceAdapter = new SinglyLoadedMemoryDataSource(storedData, store);
     const createAction = createAddDataSourceAction("jsonblob", {}, {}, adapter);

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,5 +1,5 @@
 import redux = require("redux");
-import { ModelState, DataSourceId } from "../";
+import { DataSourceId } from "../";
 import { DataAdapter } from "./";
 import { createAddDataSourceAction } from "../actions";
 import { SinglyLoadedMemoryDataSource } from "./single-memory-load-base";
@@ -14,7 +14,7 @@ class InternalMemoryDataSource extends SinglyLoadedMemoryDataSource {
     }
 }
 
-export function createMemoryDataSource(store: redux.Store<ModelState>): MemoryDataSourceAdapter {
+export function createMemoryDataSource(store: redux.Store<{}>): MemoryDataSourceAdapter {
     const base = new InternalMemoryDataSource([], store);
     const func = (((data: any[]) => {
         base.setData(data);

--- a/src/adapters/rawcsv.ts
+++ b/src/adapters/rawcsv.ts
@@ -1,13 +1,12 @@
 import redux = require("redux");
 import alasql = require("alasql");
-import { ModelState } from "../";
 import { DataAdapter } from "./";
 import { createAddDataSourceAction } from "../actions";
 import { SinglyLoadedMemoryDataSource } from "./single-memory-load-base";
 
 export interface CSVDataSourceAdapter extends DataAdapter {}
 
-export function createCSVDataSource(store: redux.Store<ModelState>, content: string): CSVDataSourceAdapter {
+export function createCSVDataSource(store: redux.Store<{}>, content: string): CSVDataSourceAdapter {
     const storedData = alasql(`SELECT * FROM CSV(?, {headers:true})`, [content]);
     const adapter: CSVDataSourceAdapter = new SinglyLoadedMemoryDataSource(storedData, store);
     const createAction = createAddDataSourceAction("rawcsv", {}, {}, adapter);

--- a/src/adapters/single-memory-load-base.ts
+++ b/src/adapters/single-memory-load-base.ts
@@ -1,11 +1,11 @@
 import redux = require("redux");
-import { ModelState, Field, DataSourceId } from "../";
+import { Field, DataSourceId } from "../";
 import { DataAdapter } from "./";
 import { createUpdateDataCacheAction, createRemoveDataSourceAction, createAddFieldsAction } from "../actions";
 import { poisonPill } from "../util";
 
 export class SinglyLoadedMemoryDataSource implements DataAdapter {
-    constructor(protected storedData: any[], protected store: redux.Store<ModelState>) {}
+    constructor(protected storedData: any[], protected store: redux.Store<{}>) {}
     async defaultFieldSelection(selectNumber = 2) {
         if (this.storedData.length < 1) throw new Error("Cannot select fields with a data source that has 0 tables");
         if (selectNumber === undefined) throw new Error("Field selection number cannot be null or undefined");

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -1,6 +1,7 @@
 export interface Exporter<T> {
     (): void; // OnUpdate method
     export(): Promise<T>;
+    dispose(): void;
 }
 
 export * from "./svg";

--- a/src/exporters/svg.ts
+++ b/src/exporters/svg.ts
@@ -12,18 +12,18 @@ export type SVGExporter = Exporter<{svg: string, spec: any}>;
 export function createSvgExporter(
     store: redux.Store<ModelState>,
     onChange?: (exp: SVGExporter) => void
-)
+): SVGExporter;
 export function createSvgExporter<T>(
     store: redux.Store<T>,
     select: (state: T) => ModelState,
     onChange?: (exp: SVGExporter) => void
-)
+): SVGExporter;
 export function createSvgExporter<T>(
     store: redux.Store<T>,
     selectOrOnChange?: ((state: T) => ModelState) | ((exp: SVGExporter) => void),
     onChange?: (exp: SVGExporter) => void
-) {
-    let select = (s => s);
+): SVGExporter {
+    let select = ((s: any) => s);
     if (onChange) {
         select = selectOrOnChange as (state: T) => ModelState;
     }

--- a/src/exporters/svg.ts
+++ b/src/exporters/svg.ts
@@ -7,15 +7,38 @@ import {
 import {compileState} from "../mapper";
 import {Exporter} from "./";
 
+export type SVGExporter = Exporter<{svg: string, spec: any}>;
 
-export function createSvgExporter(store: redux.Store<ModelState>) {
+export function createSvgExporter(
+    store: redux.Store<ModelState>,
+    onChange?: (exp: SVGExporter) => void
+)
+export function createSvgExporter<T>(
+    store: redux.Store<T>,
+    select: (state: T) => ModelState,
+    onChange?: (exp: SVGExporter) => void
+)
+export function createSvgExporter<T>(
+    store: redux.Store<T>,
+    selectOrOnChange?: ((state: T) => ModelState) | ((exp: SVGExporter) => void),
+    onChange?: (exp: SVGExporter) => void
+) {
+    let select = (s => s);
+    if (onChange) {
+        select = selectOrOnChange as (state: T) => ModelState;
+    }
+    else if (selectOrOnChange) {
+        onChange = selectOrOnChange as (exp: SVGExporter) => void;
+    }
+
     const updater = ((() => {
-        // On update...
-        // store.getState()
-    }) as Exporter<{svg: string, spec: any}>);
+        if (onChange) {
+            onChange(updater);
+        }
+    }) as SVGExporter);
     updater.export = async () => {
         return await new Promise<{svg: string, spec: any}>((resolve, reject) => {
-            const spec = compileState(store.getState());
+            const spec = compileState(select(store.getState()));
             const {spec: compiled} = vl.compile(spec);
             vega.parse.spec(compiled, chart => {
                 let result: string | undefined;
@@ -29,6 +52,6 @@ export function createSvgExporter(store: redux.Store<ModelState>) {
             });
         });
     };
-    store.subscribe(updater);
+    updater.dispose = store.subscribe(updater);
     return updater;
 }

--- a/src/exporters/zip.ts
+++ b/src/exporters/zip.ts
@@ -9,20 +9,20 @@ export function createZipExporter(
     store: redux.Store<ModelState>,
     library: {[index: string]: Buffer},
     onChange?: (exp: ZipExporter) => void
-)
+): ZipExporter;
 export function createZipExporter<T>(
     store: redux.Store<T>,
     library: {[index: string]: Buffer},
     select: (state: T) => ModelState,
     onChange?: (exp: ZipExporter) => void
-)
+): ZipExporter;
 export function createZipExporter<T>(
     store: redux.Store<T>,
     library: {[index: string]: Buffer},
     selectOrOnChange?: ((state: T) => ModelState) | ((exp: ZipExporter) => void),
     onChange?: (exp: ZipExporter) => void
-) {
-    let select = (s => s);
+): ZipExporter {
+    let select = ((s: any) => s);
     if (onChange) {
         select = selectOrOnChange as (state: T) => ModelState;
     }

--- a/src/exporters/zip.ts
+++ b/src/exporters/zip.ts
@@ -3,23 +3,51 @@ import JSZip = require("jszip");
 import {ModelState} from "../";
 import {Exporter, createSvgExporter} from "./";
 
-export function createZipExporter(store: redux.Store<ModelState>, libary: {[idex: string]: Buffer}) {
+export type ZipExporter =  Exporter<Uint8Array>;
+
+export function createZipExporter(
+    store: redux.Store<ModelState>,
+    library: {[index: string]: Buffer},
+    onChange?: (exp: ZipExporter) => void
+)
+export function createZipExporter<T>(
+    store: redux.Store<T>,
+    library: {[index: string]: Buffer},
+    select: (state: T) => ModelState,
+    onChange?: (exp: ZipExporter) => void
+)
+export function createZipExporter<T>(
+    store: redux.Store<T>,
+    library: {[index: string]: Buffer},
+    selectOrOnChange?: ((state: T) => ModelState) | ((exp: ZipExporter) => void),
+    onChange?: (exp: ZipExporter) => void
+) {
+    let select = (s => s);
+    if (onChange) {
+        select = selectOrOnChange as (state: T) => ModelState;
+    }
+    else if (selectOrOnChange) {
+        onChange = selectOrOnChange as (exp: ZipExporter) => void;
+    }
+
     const updater = ((() => {
-        // On update...
-        // store.getState
-    }) as Exporter<Uint8Array>);
+        if (onChange) {
+            onChange(updater);
+        }
+    }) as ZipExporter);
     updater.export = async () => {
-        const stateString = JSON.stringify(store.getState());
-        const svgExporter = createSvgExporter(store);
+        const stateString = JSON.stringify(select(store.getState()));
+        const svgExporter = createSvgExporter(store, select);
         const zip = new JSZip();
         zip.file("state.json", stateString);
         zip.file("thumnail.svg", (await svgExporter.export()).svg);
-        const keys = Object.keys(libary);
+        svgExporter.dispose();
+        const keys = Object.keys(library);
         for ( const key of keys ) {
-            zip.file(key, libary[key]);
+            zip.file(key, library[key]);
         }
         return await zip.generateAsync({ type: "nodebuffer" });
     };
-    store.subscribe(updater);
+    updater.dispose = store.subscribe(updater);
     return updater;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,14 @@ export * from "./actions";
 export * from "./mapper";
 
 import {createStore, combineReducers, Store} from "redux";
-import * as reducers from "./reducers";
+import * as allReducers from "./reducers";
 import {ModelState} from "./model";
+import {AllActions} from "./actions";
 
+
+export const reducer: (state: ModelState, action: AllActions) => ModelState = combineReducers<ModelState>(allReducers as any as {[index: string]: () => any});
 export function createModel(): Store<ModelState> {
-    return createStore(combineReducers<ModelState>(reducers as any as {[index: string]: () => any}));
+    return createStore(reducer);
 }
 
 export * from "./adapters";

--- a/src/test/importer.spec.ts
+++ b/src/test/importer.spec.ts
@@ -122,6 +122,8 @@ function dispatchSequence(model: Store<glacier.ModelState>, ...actions: glacier.
     actions.forEach(action => model.dispatch(action));
 }
 
+function identity<T>(a: T) { return a; }
+
 function baseline(
     readableName: string,
     baselineFilename: string,
@@ -136,7 +138,7 @@ function baseline(
         const fieldAction = glacier.createAddFieldsAction(fields);
         const actions = makeActions(n => fieldAction.payload.fields[n].id);
         dispatchSequence(model, fieldAction, ...actions);
-        const exporter = glacier.createSvgExporter(model);
+        const exporter = glacier.createSvgExporter(model, identity);
 
         for (const a of adapters) {
             await a.updateCache();
@@ -328,7 +330,7 @@ describe("glacier as a model", () => {
 
         const glacierLib = fs.readFileSync(root`./dist/local/glacier.js`);
         const indexHtml = fs.readFileSync(root`./data/index.html`);
-        const exportedBundle = glacier.createZipExporter(model, { "glacier.js": glacierLib, "index.html": indexHtml });
+        const exportedBundle = glacier.createZipExporter(model, { "glacier.js": glacierLib, "index.html": indexHtml }, identity);
         await adapter.updateCache();
         const zip = await exportedBundle.export();
         const loadedZip = await new jszip().loadAsync(zip);


### PR DESCRIPTION
Specifically, this allows consumers to wrap our reducers to create a larger state, like so:
```ts
import { createStore } from "redux";
import { ModelState, createSvgExporter, reducer } from "glacier";

const dispReducer = (action: {type: "UPDATE_VIZ_PREVIEW", payload: string}, state: DispState) => {
  if (action.type === "UPDATE_VIZ_PREVIEW") {
    return {viz: action.payload};
  }
  return {...state};
};
const topLevel = combineReducers<{glacier: ModelState, display: DispState}>({
  glacier: reducer, display: dispReducer
});

const model = createStore(topLevel);
const svg = createSvgExporter(store, s => s.glacier);
// dispatch actions on `model` as normal.
```

This is useful, since the conventional `redux` paradigm uses just one top-level store; so if your app is using `redux` for state management, this lets you incorporate `glacier` into your state as you see fit. I ran into this when working on the demo, as I already had `redux` in place for managing my UI state. To support this, the adapters and exports which relied on specifically-typed stores have been made more generic, and, where required, now have overloads to take a selector to find the correct state fragment if loaded with a store which is not a simple `ModelState`. Additionally, the result of `combineReducers` on all our internal reducers is now directly exported, to save consumers some work we already did inside our `createModel` function.

Additionally, exporters now have a `dispose` method which unsubscribes them from the model - used correctly, this can prevent memory leaks caused by short-lived exporters (as the one created in the `zip` exporter). It may be desirable to poison the `export` method after `dispose` is called. (Also fixed a typo: `libary`-> `library`)

Also bumped the TS version to latest stable, because performance and QOL improvements. Also generic default types if you're interested in using them.