### PR TITLE
Use `prepare` instead of `install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "gulp test",
-    "install": "cd src && npm install && cd ../"
+    "prepare": "cd src && npm install && cd ../"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
They're almost identical for local development, however `install` ends up being run on released versions - which is undesirable for us, so we should use `prepare` instead, which gets run on a local `npm install` and prior to `publish`.