### PR TITLE
Make mapper robust to incomplete states

### DIFF
--- a/docs/baselines/local/1-structuredData.spec.json
+++ b/docs/baselines/local/1-structuredData.spec.json
@@ -1,4 +1,5 @@
 {
+    "mark": "point",
     "data": {
         "values": [
             {
@@ -2029,7 +2030,6 @@
             "type": "quantitative"
         }
     },
-    "mark": "point",
     "description": "Test Plot",
     "width": 264,
     "height": 255

--- a/docs/baselines/local/15-DJI.spec.json
+++ b/docs/baselines/local/15-DJI.spec.json
@@ -1,4 +1,5 @@
 {
+    "mark": "line",
     "data": {
         "values": [
             {
@@ -957,7 +958,6 @@
             }
         }
     },
-    "mark": "line",
     "description": "DJI v Time",
     "width": 264,
     "height": 255

--- a/docs/baselines/local/16-MPG.spec.json
+++ b/docs/baselines/local/16-MPG.spec.json
@@ -1,4 +1,5 @@
 {
+    "mark": "area",
     "data": {
         "values": [
             {
@@ -4500,7 +4501,6 @@
             "aggregate": "max"
         }
     },
-    "mark": "area",
     "description": "MPG vs Time",
     "width": 400,
     "height": 135

--- a/docs/baselines/local/2-marks.spec.json
+++ b/docs/baselines/local/2-marks.spec.json
@@ -1,4 +1,5 @@
 {
+    "mark": "line",
     "data": {
         "values": [
             {
@@ -2029,7 +2030,6 @@
             "type": "quantitative"
         }
     },
-    "mark": "line",
     "description": "Test Plot",
     "width": 264,
     "height": 255

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
 <body>
 	
     <div id="timestamp">
-        Last Generated: Tue Apr 04 2017 20:44:34 GMT+0000 (UTC)
+        Last Generated: Mon May 08 2017 02:04:14 GMT+0000 (UTC)
     </div>
 
 	<table>

--- a/src/test/importer.spec.ts
+++ b/src/test/importer.spec.ts
@@ -628,4 +628,16 @@ describe("glacier as a model", () => {
         let state = model.getState();
         expect(Object.keys(state.fields).length).to.equal(2);
     });
+
+    it("should be able to handle calls to export before fields are added", async () => {
+        const model = glacier.createModel();
+        glacier.createMemoryDataSource(model)(require(root`./data/cars.json`));
+        const e = glacier.createSvgExporter(model);
+        const r1 = await e.export();
+        expect(r1).to.exist;
+        model.dispatch(glacier.createUpdateSizeAction(200, 200));
+        const r2 = await e.export();
+        expect(r2).to.exist;
+        expect(r2.spec.height).to.equal(200);
+    });
 });


### PR DESCRIPTION
This way a spec can still be exported/generated even when the state does not contain a complete description of a visualization.