### PR TITLE
Fix zero mapping

### DIFF
--- a/src/mapper/index.ts
+++ b/src/mapper/index.ts
@@ -25,7 +25,7 @@ function remapFieldsToNames(channels: ChannelState, fields: FieldState): Channel
         const ch = channels[key];
         let replacement: ChannelDef | undefined = undefined;
         if (ch) {
-            if (ch.field) {
+            if (typeof ch.field !== "undefined") {
                 const f = ch.field;
                 if (typeof f === "number") {
                     replacement = { ...ch, field: lookupName(f, fields) } as ChannelDef;
@@ -44,7 +44,7 @@ function remapFieldsToJoinNames(channels: ChannelState, fields: FieldState): Cha
         const ch = channels[key];
         let replacement: ChannelDef | undefined = undefined;
         if (ch) {
-            if (ch.field) {
+            if (typeof ch.field !== "undefined") {
                 const f = ch.field;
                 if (typeof f === "number") {
                     replacement = { ...ch, field: `${lookupName(f, fields)}_${f}` } as ChannelDef;


### PR DESCRIPTION
Previously, if a field with id zero was referenced by id, its id would not get mapped to its name in the encoding field, potentially messing up the data displayed in the visualization.